### PR TITLE
Revert "waffle.io Badge"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Stories in Ready](https://badge.waffle.io/codeforhuntsville/Frontier.png?label=ready&title=Ready)](https://waffle.io/codeforhuntsville/Frontier)
-[![Stories in Ready](https://badge.waffle.io/codeforhuntsville/Frontier.png?label=ready&title=Ready)](https://waffle.io/codeforhuntsville/Frontier)
 # Frontier
 A civic app for finding whats near me
 


### PR DESCRIPTION
Reverts codeforhuntsville/Frontier#3 because there was already a badge on the readme
