### PR TITLE
Make ngrok an optional dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,19 @@ var server = require('./lib/server')();
 var config = require('config');
 var port = config.get('port');
 
+function ngrokIsAvailable() {
+  try {
+    require.resolve('ngrok');
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 server.listen(port, function () {
   console.log('listening on port ' + port);
 
-  if (process.env.NODE_ENV === 'development') {
+  if (process.env.NODE_ENV === 'development' && ngrokIsAvailable()) {
     require('ngrok').connect(port, function (err, url) {
       if (err) {
         console.error('ngrok error', err);

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "keywords": [],
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.4.1",
+    "bower": "^1.4.1"
+  },
+  "optionalDependencies": {
     "ngrok": "^0.1.99"
   },
   "dependencies": {


### PR DESCRIPTION
This patch makes ngrok an optional dependency, so that users that are behind firewalls that disallow the ngrok url can still complete their npm install. If the ngrok install is successful, an ngrok url will be provided upon server start.
