### PR TITLE
Guard against a non-array restaurants result

### DIFF
--- a/lib/routes/restaurants.js
+++ b/lib/routes/restaurants.js
@@ -60,6 +60,12 @@ router.get('/', function (req, res) {
     }
 
     results = body.results;
+
+    if (!results || !Array.isArray(results)) {
+      res.send([]);
+      return;
+    }
+
     for (var i = 0; i < 10; i++) {
       result = results[i];
       if (!result) {

--- a/public/app/index.js
+++ b/public/app/index.js
@@ -32,6 +32,11 @@
 
     getRestaurants(position.coords)
       .then(function (restaurants) {
+        if (!Array.isArray(restaurants) || !restaurants.length) {
+          $status.innerHTML = 'No restaurants found in your area.';
+          return;
+        }
+
         $status.innerHTML = restaurants.map(function (r) {
           return r.name + '<br />';
         }).join('');


### PR DESCRIPTION
I have no idea how this would happen, since the backend seems to return an array result on success, even if there are no restaurants available, or the `results` property in the google places response does not exist. Anyway, this should address that problem. I'd be interested in seeing what server response triggers this code.

Closes #18
