### PR TITLE
Add CSS cursor style to body element

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -17,5 +17,6 @@
 
 body {
     text-align: left;
-    background-color: #eee
+    background-color: #eee;
+    cursor: pointer;
 }


### PR DESCRIPTION
In order for Safari iOS to bubble up mouse events, the target element or
any of its ancestors must have a "cursor: pointer" CSS declaration.

The lack of this declaration was preventing the Location component from
executing its click handler when the compass button was pressed on an
iPhone and in the iOS simulator, so it could not even display an error.

Reference:
http://www.quirksmode.org/blog/archives/2014/02/mouse_event_bub.html
