### PR TITLE
Added tests for the Location component

### DIFF
--- a/lib/client/components/Location.jsx
+++ b/lib/client/components/Location.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from 'react';
+var Geolocation = require('../util/Geolocation');
 
 export default class Location extends React.Component {
 
@@ -11,17 +12,18 @@ export default class Location extends React.Component {
   }
 
   handleClick() {
-    navigator.geolocation.getCurrentPosition(
+    this.setState({ location: 'Fetching location...', error: '' });
+
+    Geolocation.getCurrentPosition(
       geo => {
         const lat = geo.coords.latitude;
         const lon = geo.coords.longitude;
 
-        this.setState({ lat, lon, location: `${lat}, ${lon}`, error: '' });
+        this.setState({ lat, lon, location: `${lat.toFixed(4)}, ${lon.toFixed(4)}`, error: '' });
       },
       () => {
-        this.setState({ error: 'Could not get your location' });
-      }
-    )
+        this.setState({ location: null, lat: 0, lon: 0, error: 'Could not get your location' });
+      });
   }
 
   render() {

--- a/lib/client/components/__tests__/Location-test.jsx
+++ b/lib/client/components/__tests__/Location-test.jsx
@@ -1,0 +1,57 @@
+jest.dontMock('../Location.jsx');
+
+var React = require('react/addons');
+var TestUtils = React.addons.TestUtils;
+var Location = require('../Location.jsx');
+var Geolocation = require('../../util/Geolocation');
+
+describe('The Location component', function () {
+
+  var location, input, image;
+
+  beforeEach(function () {
+    Geolocation.__disable();
+
+    location = TestUtils.renderIntoDocument(<Location />);
+    input = TestUtils.findRenderedDOMComponentWithTag(location, 'input');
+    image = TestUtils.findRenderedDOMComponentWithTag(location, 'i');
+  });
+
+  it('displays a message when fetching geolocation data', function () {
+    TestUtils.Simulate.click(image);
+    expect(input.getDOMNode().value).toEqual('Fetching location...');
+  });
+
+  it('displays lat and lon when geolocation fetch succeeds', function () {
+    Geolocation.__setLocation(34.73004, -86.585);
+    TestUtils.Simulate.click(image);
+    expect(input.getDOMNode().value).toEqual('34.7300, -86.5850');
+  });
+
+  describe('when fetching geolocation data fails', function () {
+
+    beforeEach(function () {
+      Geolocation.__enable();
+      TestUtils.Simulate.click(image);
+    });
+
+    it('displays an error message', function () {
+      var p = TestUtils.findRenderedDOMComponentWithTag(location, 'p');
+      expect(p.getDOMNode().textContent).toEqual('Could not get your location');
+    });
+
+    it('resets the input field', function () {
+      expect(input.getDOMNode().value).toBeNull();
+    });
+
+    it('clears the error when another fetch is attempted', function () {
+      Geolocation.__disable();
+      TestUtils.Simulate.click(image);
+
+      var ps = TestUtils.scryRenderedDOMComponentsWithTag(location, 'p');
+      expect(ps.length).toBe(0);
+    });
+
+  });
+
+});

--- a/lib/client/util/Geolocation.js
+++ b/lib/client/util/Geolocation.js
@@ -1,0 +1,17 @@
+// This module exists so that we mock the API in tests.
+
+export default class Geolocation {
+
+  static getCurrentPosition(successCallback, errorCallback, options) {
+    navigator.geolocation.getCurrentPosition(successCallback, errorCallback, options);
+  }
+
+  static watchPosition(successCallback, errorCallback, options) {
+    return navigator.geolocation.watchPosition(successCallback, errorCallback, options);
+  }
+
+  static clearWatch(watchId) {
+    navigator.geolocation.clearWatch(watchId);
+  }
+
+}

--- a/lib/client/util/__mocks__/Geolocation.js
+++ b/lib/client/util/__mocks__/Geolocation.js
@@ -1,0 +1,37 @@
+var path = require.requireActual('../Geolocation');
+
+var geoMock = jest.genMockFromModule('../Geolocation');
+
+var _coords = null;
+var _enabled = false;
+function __setLocation(lat, lon) {
+  _enabled = true;
+  _coords = { latitude: lat, longitude: lon };
+}
+
+function __enable() {
+  _enabled = true;
+}
+
+function __disable() {
+  _coords = null;
+  _enabled = false;
+}
+
+function getCurrentPosition(successCallback, errorCallback) {
+  if(_enabled) {
+    if(_coords) {
+      successCallback({ coords: _coords });
+    }
+    else {
+      errorCallback();
+    }
+  }
+}
+
+geoMock.getCurrentPosition.mockImplementation(getCurrentPosition);
+geoMock.__enable = __enable;
+geoMock.__disable = __disable;
+geoMock.__setLocation = __setLocation;
+
+module.exports = geoMock;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "webpack",
     "start": "NODE_ENV=development webpack && NODE_ENV=development node index.js",
     "start-prod": "NODE_ENV=production webpack && NODE_ENV=production node index.js",
-    "lint": "jshint . && jscs ."
+    "lint": "jshint . && jscs .",
+    "test": "jest"
   },
   "keywords": [],
   "license": "MIT",
@@ -32,9 +33,18 @@
     "imports-loader": "^0.6.3",
     "node-libs-browser": "^0.5.0",
     "webpack": "^1.9.7",
-    "webpack-dev-middleware": "^1.0.11"
+    "webpack-dev-middleware": "^1.0.11",
+    "jest-cli": "^0.4.13",
+    "react-tools": "^0.13.3",
+    "babel-jest": "^5.3.0"
   },
   "optionalDependencies": {
     "ngrok": "^0.1.99"
+  },
+  "jest": {
+    "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",
+    "testFileExtensions": ["js", "jsx"],
+    "moduleFileExtensions": ["js", "jsx"],
+    "unmockedModulePathPatterns": ["react"]
   }
 }


### PR DESCRIPTION
We do not currently have any tests in the client portion of the code, so I'm just throwing this out to start a discussion on it.  These tests are built using Facebook's Jest test library.

The tests take a few seconds to run because the JSX has to be transformed before execution.  We can improve performance of the tests later by caching the transformation results.
