### PR TITLE
Feature/bound categories

### DIFF
--- a/lib/client/actions/CategoryActions.jsx
+++ b/lib/client/actions/CategoryActions.jsx
@@ -1,0 +1,4 @@
+'use strict';
+
+import alt from '../alt.js';
+export default alt.generateActions('updateCategory');

--- a/lib/client/actions/LocationActions.jsx
+++ b/lib/client/actions/LocationActions.jsx
@@ -1,12 +1,4 @@
 'use strict';
 
 import alt from '../alt.js';
-
-class LocationActions {
-  locationUpdate() {
-    this.dispatch();
-  }
-
-}
-
-export default alt.createActions(LocationActions);
+export default alt.generateActions('locationUpdate');

--- a/lib/client/components/CategoryButton.jsx
+++ b/lib/client/components/CategoryButton.jsx
@@ -1,18 +1,34 @@
 'use strict';
+
 import React from 'react';
+import { Component, PropTypes } from 'react';
 
-export default class CategoryButton extends React.Component {
+export default class CategoryButton extends Component {
 
-  render() {
-    return (
-      <i className={ `fa ${this.props.iconClass} fa-2x` }></i>
-    );
+  constructor(...args) {
+    super(...args);
+    this.handleClick = this.handleClick.bind(this);
   }
 
+  handleClick() {
+    const { onClick, category } = this.props;
+    onClick(category);
+  }
+
+  render() {
+    const { category } = this.props;
+    let className = `fa ${category.iconClass} fa-2x`;
+    if (category.selected) {
+      className += ' selected';
+    }
+
+    return (
+      <i className={ className } onClick={ this.handleClick }></i>
+    );
+  }
 }
 
 CategoryButton.propTypes = {
-  iconClass: React.PropTypes.string,
-  selected: React.PropTypes.bool,
-  onClick: React.PropTypes.func
+  category: PropTypes.object,
+  onClick: PropTypes.func
 };

--- a/lib/client/components/CategoryList.jsx
+++ b/lib/client/components/CategoryList.jsx
@@ -1,21 +1,28 @@
 'use strict';
 
 import React from 'react';
+import { Component, PropTypes } from 'react';
 import CategoryButton from './CategoryButton.jsx';
 
-export default class CategoryList extends React.Component {
-  constructor(props) {
-    super(props);
+export default class CategoryList extends Component {
+
+  constructor(...args) {
+    super(...args);
   }
 
   render() {
+    const { categories, categoryClick } = this.props;
     return (
       <div className="col-xs-12">
         <h3>Categories</h3>
-
-        <div id="categories" style={{ width: "100%" }}>{
-          this.props.categories.map(c => {
-            return <CategoryButton key={ c.iconClass } iconClass={ c.iconClass }/>
+        <div id="categories" style={{ width: "100%" }}>
+        {
+          categories.map(c => {
+            return <CategoryButton
+              key={ c.category }
+              category={ c }
+              onClick={ categoryClick }
+            />
           })
         }
         </div>
@@ -24,3 +31,7 @@ export default class CategoryList extends React.Component {
   }
 }
 
+CategoryList.propTypes = {
+  categories: PropTypes.arrayOf(PropTypes.object).isRequired,
+  categoryClick: PropTypes.func.isRequired
+};

--- a/lib/client/components/HomeView.jsx
+++ b/lib/client/components/HomeView.jsx
@@ -3,16 +3,41 @@ import React from 'react';
 import Location from './Location.jsx';
 import CategoryList from './CategoryList.jsx';
 import Slider from './Slider.jsx';
+import CategoryStore from '../stores/CategoryStore.jsx';
+import CategoryActions from '../actions/CategoryActions.jsx';
 
 export default class HomeView extends React.Component {
 
+  static onCategoryClick(category) {
+    category.selected = !category.selected;
+    CategoryActions.updateCategory(category);
+  }
+
+  constructor(...args) {
+    super(...args);
+
+    this.state = {
+      categories: CategoryStore.getAllCategories()
+    };
+
+    this._onChange = this._onChange.bind(this);
+  }
+
+  _onChange() {
+    this.setState({
+      categories: CategoryStore.getAllCategories()
+    });
+  }
+  componentDidMount() {
+    CategoryStore.listen(this._onChange);
+  }
+
+  componentWillUnmount() {
+    CategoryStore.unlisten(this._onChange);
+  }
+
   render() {
-    const categories = [
-      { iconClass: 'fa-cutlery' },
-      { iconClass: 'fa-wifi' },
-      { iconClass: 'fa-hotel' },
-      { iconClass: 'fa-beer' }
-    ];
+    const { categories } = this.state;
 
     return (
       <div className="container-fluid">
@@ -24,7 +49,7 @@ export default class HomeView extends React.Component {
               <Location />
             </div>
             <div className="row">
-              <CategoryList categories={ categories }/>
+              <CategoryList categories={ categories } categoryClick={ HomeView.onCategoryClick } />
             </div>
             <div className="row">
               <Slider minValue={ 0 } maxValue={ 20 } stepSize={ 5 } units="miles" />

--- a/lib/client/index.jsx
+++ b/lib/client/index.jsx
@@ -1,4 +1,8 @@
 'use strict';
+
+// polyfill required for ES6 Array.find()
+require('babel-core/polyfill');
+
 import React from 'react';
 import Router from 'react-router';
 import { DefaultRoute, Route, RouteHandler } from 'react-router';

--- a/lib/client/index.jsx
+++ b/lib/client/index.jsx
@@ -27,6 +27,6 @@ let routes = (
   </Route>
 );
 
-Router.run(routes, (Handler) => {
+Router.run(routes, Router.HistoryLocation, (Handler) => {
   React.render(<Handler />, document.getElementById('outlet'));
 });

--- a/lib/client/stores/CategoryStore.jsx
+++ b/lib/client/stores/CategoryStore.jsx
@@ -1,0 +1,38 @@
+'use strict';
+
+import alt from '../alt.js';
+import CategoryActions from '../actions/CategoryActions.jsx';
+
+class CategoryStore {
+
+  constructor() {
+    this.categories = [
+      { category: 'restaurants', iconClass: 'fa-cutlery', selected: false },
+      { category: 'wifi', iconClass: 'fa-wifi', selected: false },
+      { category: 'hotels', iconClass: 'fa-hotel', selected: false },
+      { category: 'bars', iconClass: 'fa-beer', selected: false }
+    ];
+
+    this.bindListeners({
+      handleCategoryUpdate: CategoryActions.UPDATE_CATEGORY
+    });
+
+    this.exportPublicMethods({
+      getAllCategories: this.getAllCategories
+    })
+  }
+
+  handleCategoryUpdate(updated) {
+    let category = this.categories.find(c => c.category === updated.category);
+
+    if (category) {
+      category.selected = updated.selected;
+    }
+  }
+
+  getAllCategories() {
+    return this.getState().categories;
+  }
+}
+
+export default alt.createStore(CategoryStore, 'CategoryStore');

--- a/public/style.css
+++ b/public/style.css
@@ -15,6 +15,10 @@
     text-align: center;
 }
 
+#categories i.fa.selected {
+  background-color: red;
+}
+
 body {
     text-align: left;
     background-color: #eee;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,7 +17,7 @@ var config = {
       }
     ]
   },
-  devtool: 'source-map',
+  devtool: 'eval-source-map',
   plugins: [
     // don't emit a broken build when errors occur
     new webpack.NoErrorsPlugin(),


### PR DESCRIPTION
This PR makes the category buttons selectable and stores their selection state in a Flux store. It also changes the webpack devtool to 'eval-source-map' for easier debugging in the browser, and switches the react-router to use the History API instead of a hash in the URL, making for cleaner URLs.
